### PR TITLE
Fix: Postgres connection

### DIFF
--- a/apps/cli/template/with-drizzle-postgres/apps/server/drizzle.config.ts
+++ b/apps/cli/template/with-drizzle-postgres/apps/server/drizzle.config.ts
@@ -5,6 +5,6 @@ export default defineConfig({
   out: "./src/db/migrations",
   dialect: "postgresql",
   dbCredentials: {
-    url: process.env.POSTGRES_URL || "",
+    url: process.env.DATABASE_URL || "",
   },
 });

--- a/apps/cli/template/with-drizzle-postgres/apps/server/src/db/index.ts
+++ b/apps/cli/template/with-drizzle-postgres/apps/server/src/db/index.ts
@@ -2,4 +2,4 @@ import { drizzle } from "drizzle-orm/postgres-js";
 import postgres from "postgres";
 
 const queryClient = postgres(process.env.DATABASE_URL);
-const db = drizzle({ client: queryClient });
+export const db = drizzle({ client: queryClient });

--- a/apps/cli/template/with-drizzle-postgres/apps/server/src/db/index.ts
+++ b/apps/cli/template/with-drizzle-postgres/apps/server/src/db/index.ts
@@ -1,5 +1,5 @@
 import { drizzle } from "drizzle-orm/postgres-js";
 import postgres from "postgres";
 
-const queryClient = postgres(process.env.DATABASE_URL);
+const queryClient = postgres(process.env.DATABASE_URL || "");
 export const db = drizzle({ client: queryClient });


### PR DESCRIPTION
This PR comes with a few fixes:

1. Fixes Postgres CLI connection by adding the correct Env var to Drizzle config
2. Export the DB instance so auth instance can have access to it
3. Fix lint error
